### PR TITLE
Support colon in service name.

### DIFF
--- a/exec.go
+++ b/exec.go
@@ -27,9 +27,13 @@ func (cmd *execCmd) Run(fs *flag.FlagSet) {
 	cmd.InitClient(false)
 	cmd.exitStatus = 0
 
-	mapping := strings.SplitN(fs.Arg(0), ":", 2)
-	name := mapping[0]
-	port := mapping[1]
+	colonIdx := strings.LastIndex(fs.Arg(0), ":")
+	if colonIdx == -1 {
+		fmt.Println("specify services in name:port format:", fs.Arg(0))
+		os.Exit(1)
+	}
+	name := fs.Arg(0)[0:colonIdx]
+	port := fs.Arg(0)[colonIdx+1:]
 
 	cmd.ValidateFlags()
 


### PR DESCRIPTION
There are also issues with a slash, I think on the discoverd side of things, but this will allow colons as separators.
